### PR TITLE
Fix Undefined array key "scripts" error

### DIFF
--- a/src/TrackingCodeTags.php
+++ b/src/TrackingCodeTags.php
@@ -26,7 +26,7 @@ class TrackingCodeTags extends Tags
         ->merge(YAML::file(base_path('content/tracking-codes.yaml'))->parse())
         ->all();
 
-        if(!isset($values['enabled']) && $values['enabled'] == false || !isset($values['scripts'])){
+        if(!isset($values['enabled']) || $values['enabled'] == false || !isset($values['scripts'])){
             return '';
         }
         

--- a/src/TrackingCodeTags.php
+++ b/src/TrackingCodeTags.php
@@ -26,7 +26,7 @@ class TrackingCodeTags extends Tags
         ->merge(YAML::file(base_path('content/tracking-codes.yaml'))->parse())
         ->all();
 
-        if($values['enabled'] == false){
+        if(!isset($values['enabled']) && $values['enabled'] == false || !isset($values['scripts'])){
             return '';
         }
         


### PR DESCRIPTION
Fix Undefined array key "scripts" error that appears after installing the package and not changing the settings.