### PR TITLE
Update cp.php routes to have the right middleware

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -1,6 +1,6 @@
 <?php
 
-Route::middleware('web')->group(function () {
+Route::middleware('statamic.cp.authenticated')->group(function () {
     Route::get('/simonridley/trackingcodemanager/', '\Simonridley\TrackingCodeManager\Http\Controllers\TrackingCodeManagerController@index')->name('simonridley.tracking-code-manager.index');
     Route::post('/simonridley/trackingcodemanager/', '\Simonridley\TrackingCodeManager\Http\Controllers\TrackingCodeManagerController@update')->name('simonridley.tracking-code-manager.update');
 });


### PR DESCRIPTION
fixes a bug that logs the user out because of the middleware