### PR TITLE
Statamic v5 fix code embed

### DIFF
--- a/src/TrackingCodeTags.php
+++ b/src/TrackingCodeTags.php
@@ -38,7 +38,11 @@ class TrackingCodeTags extends Tags
 
         $output = '<!-- tracking code manager '.$tag.' scripts -->';
         foreach($scripts as $script){
-            $output .= $script['code'];
+            if (is_array($script)) {
+                $script = $script['code'];
+            }
+            
+            $output .= $script;
         }
         $output .= '<!-- end tracking code manager '.$tag.' scripts -->';
         return $output;

--- a/src/TrackingCodeTags.php
+++ b/src/TrackingCodeTags.php
@@ -38,7 +38,7 @@ class TrackingCodeTags extends Tags
 
         $output = '<!-- tracking code manager '.$tag.' scripts -->';
         foreach($scripts as $script){
-            $output .= $script;
+            $output .= $script['code'];
         }
         $output .= '<!-- end tracking code manager '.$tag.' scripts -->';
         return $output;


### PR DESCRIPTION
I installed this package on Statamic v5 and got this error:

```
ErrorException: Array to string conversion in file vendor/simonridley/tracking-code-manager/src/TrackingCodeTags.php on line 41
```

The `code` fields of `tracking-codes.yaml` are now apparently nested one level deeper:

```
enabled: true
scripts:
  -
    id: lxsrgt5v
    enabled: true
    name: 'Cookie Banner'
    script:
      code: '<script src="..."></script>'
      mode: htmlmixed
    position: head
```

So changing the line proposed in this PR fixed my issue.